### PR TITLE
fix: Remote Source Code Loading Bug

### DIFF
--- a/docs/lib/remote-source-examples/remote-src/index.tsx
+++ b/docs/lib/remote-source-examples/remote-src/index.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+export default function Index() {
+  return (
+    <>
+      <h1>Hello World!</h1>
+      <p>This source code was loaded from the server!</p>
+    </>
+  );
+}

--- a/docs/lib/remote-source.js
+++ b/docs/lib/remote-source.js
@@ -1,0 +1,81 @@
+// Note: this file will be used in getStaticProps and must use CJS
+const fsp = require("fs/promises");
+const path = require("path");
+const fs = require("fs");
+
+const entryFilePattern = /^index\..*\.[tj]sx?/;
+const demosBaseDir = path.resolve(
+  process.cwd(),
+  "./lib/remote-source-examples"
+);
+// const demosBaseDir = path.resolve(process.cwd(), './pages/demos');
+
+/**
+ *
+ * @param {string} pathOrDir
+ * @returns {Promise<string[]>}
+ */
+async function getRemoteEntries(pathOrDir) {
+  // check if dir is a directory
+  const stat = await fsp.stat(pathOrDir);
+  if (!stat.isDirectory()) {
+    if (entryFilePattern.test(path.basename(pathOrDir))) {
+      return [pathOrDir];
+    }
+    return [];
+  }
+  // build directory structure recursively
+  const paths = await fsp.readdir(pathOrDir);
+  const results = await Promise.all(
+    paths.map(async (p) => {
+      const fullPath = path.join(pathOrDir, p);
+      return getRemoteEntries(fullPath);
+    })
+  );
+  return results.flat();
+}
+
+async function getRemoteSourceExamples() {
+  const paths = await getRemoteEntries(demosBaseDir);
+  return paths.map((p) => {
+    const entry = path.relative(demosBaseDir, p);
+    return entry.substring(0, entry.lastIndexOf("/"));
+  });
+}
+
+/**
+ *
+ * @param {string} entryDir
+ * @returns {Promise<string[]>}
+ */
+async function getRemoteSourceFiles(entryDir) {
+  const filenames = await fsp.readdir(path.join(demosBaseDir, entryDir));
+
+  filenames.sort((a, b) => {
+    // makes sure entry is at the top
+    return entryFilePattern.test(a) ? -1 : 1;
+  });
+
+  const inputFiles = await Promise.all(
+    filenames.map(async (filename) => {
+      const content = await fsp.readFile(
+        path.join(demosBaseDir, entryDir, filename),
+        "utf8"
+      );
+      // Strip off page extension
+      const newFilename = filename.replace(".page", "");
+      return {
+        code: content,
+        filename: newFilename,
+      };
+    })
+  );
+
+  return inputFiles;
+}
+
+module.exports = {
+  getDemos: getRemoteSourceExamples,
+  getDemoFiles: getRemoteSourceFiles,
+  getDemoEntries: getRemoteEntries,
+};

--- a/docs/pages/api/remote-files.ts
+++ b/docs/pages/api/remote-files.ts
@@ -1,0 +1,18 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+import { getDemoFiles } from "../../lib/remote-source";
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { src } = req.query;
+  if (Array.isArray(src) || !src) {
+    return res.status(400).json({
+      error: "src must be a string",
+    });
+  }
+  res.json({
+    files: await getDemoFiles(src),
+  });
+}

--- a/docs/pages/remote-source.tsx
+++ b/docs/pages/remote-source.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import { useInitMonaco } from "../components/use-init-monaco";
+import { InputFile } from "code-kitchen/src/types";
+import { Playground } from "code-kitchen";
+import dependencies from "../components/dependencies";
+
+export default function Page() {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonText = isOpen ? "Close Playground" : "Open Playground";
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        style={{
+          backgroundColor: "lightgray",
+          border: "solid 1px darkgrey",
+          borderRadius: "4px",
+          padding: "4px 8px",
+          margin: "8px 16px",
+        }}
+      >
+        {buttonText}
+      </button>
+      {isOpen ? <RemoteSourcePlayground src="remote-src" /> : null}
+    </>
+  );
+}
+
+function useRemoteSources(src?: string) {
+  const [files, setFiles] = React.useState<InputFile[] | null>(null);
+  React.useEffect(() => {
+    if (src) {
+      let cancelled = false;
+      fetch(`/api/remote-files?src=${encodeURIComponent(src)}`).then(
+        async (res) => {
+          if (cancelled) {
+            return;
+          }
+          const { files } = await res.json();
+          setFiles(files);
+        }
+      );
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [src]);
+  return files;
+}
+
+const customRequire = (key: string) => {
+  const res = (dependencies as any)[key];
+
+  if (res) {
+    return res;
+  }
+
+  throw new Error("DEP: " + key + " not found");
+};
+
+function RemoteSourcePlayground({ src }: { src: string }) {
+  useInitMonaco();
+  const remoteSources = useRemoteSources(src);
+  const [initialFiles, setInitialFiles] = React.useState<InputFile[]>([]);
+  const latestInitialFiles = React.useRef<InputFile[]>([]);
+
+  React.useEffect(() => {
+    const newInitialFiles = remoteSources ?? [];
+    setInitialFiles(newInitialFiles);
+    latestInitialFiles.current = newInitialFiles;
+  }, [remoteSources]);
+
+  return (
+    <Playground
+      id={"code-kitchen-playground"}
+      allowDisconnect
+      name="Playground"
+      className="h-screen"
+      require={customRequire}
+      initialFiles={initialFiles}
+    />
+  );
+}

--- a/packages/code-kitchen/src/files-editor.tsx
+++ b/packages/code-kitchen/src/files-editor.tsx
@@ -39,7 +39,10 @@ function useModels(id: string, files: InputFile[]) {
     }
     const getFileUri = (filename: string) =>
       monaco.Uri.file(join(id, filename));
-    if (!modelsRef.current) {
+    if (
+      !modelsRef.current ||
+      (modelsRef.current.length === 0 && files.length > 0)
+    ) {
       const newModels = files.map((f) => {
         return monaco.editor.createModel(
           f.code,


### PR DESCRIPTION
We've encountered an issue with loading source code examples from a remote end point.  In our case the playground is not rendered on the client initially.  When we do open the playground, we want the code visible immediately.  On the first interaction to open the playground the code is displayed as expected.  However, if we close the playground and attempt to reopen it, the code is not displayed.  Clicking the hide code/show code button to toggle the Playground code editor allows the code to be visible again. 

The code seems to be properly loaded from the endpoint, yet its not displayed in the editor pain.

Consider the following video example:

https://github.com/freewheel/code-kitchen/assets/12767362/1ec76c91-63ea-4f39-9875-0abc2b10ba27

Solution: 
After debugging is seems like the underlying code mode was being initialized to an empty array.  After the files were imported from from the remote server, the underlying models were not being updated with the new file contents. 

This [97b8225](https://github.com/freewheel/code-kitchen/pull/23/commits/97b8225083688337cbbed7e015aad689f0c4cbca) re-initializes the array of models if it's an empty array and array of files contains items.  With this change the code samples are properly loaded into the file viewer.

https://github.com/freewheel/code-kitchen/assets/12767362/286e9382-1a9f-4419-a331-2408cbf7d212
