### PR TITLE
Archive the project

### DIFF
--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -68,3 +68,13 @@ export const pre = (props) => {
     </pre>
   );
 };
+
+export const ArchiveBanner = () => {
+  return (
+    <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-900 px-4 py-3 mb-6 rounded font-sans text-sm">
+      <strong>⚠️ Archived Repository</strong> — This repository is archived and
+      is no longer actively maintained. No new issues, pull requests, or
+      releases will be accepted.
+    </div>
+  );
+};

--- a/docs/pages/[id].tsx
+++ b/docs/pages/[id].tsx
@@ -8,9 +8,10 @@ import { Playground } from "../components/MDXPlayground";
 
 const components = { Playground, ...mdxComponents };
 
-export default function Post({ source }) {
+export default function Post({ source, id }) {
   return (
     <div className="max-w-3xl mx-auto py-12 px-8">
+      {id === "home" && <mdxComponents.ArchiveBanner />}
       <MDXRemote {...source} components={components} />
     </div>
   );
@@ -29,6 +30,6 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params }) {
   const data = await getPostData(params.id);
   return {
-    props: data,
+    props: { ...data, id: params.id },
   };
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-> [!WARNING] > **This repository is archived and is no longer actively maintained.** No new issues, pull requests, or releases will be accepted.
+> [!WARNING]
+> **This repository is archived and is no longer actively maintained.** No new issues, pull requests, or releases will be accepted.
+
 
 # Code Kitchen 🧑‍🍳
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+> [!WARNING] > **This repository is archived and is no longer actively maintained.** No new issues, pull requests, or releases will be accepted.
+
 # Code Kitchen 🧑‍🍳
 
 **Code Kitchen** is a React live-coding playground which allows the developers to embed React component demos into a React UI library’s web documents.


### PR DESCRIPTION
Add a prominent archive warning banner to both the README (using GitHub-flavoured [!WARNING] callout) and the GitHub Pages homepage.

The site banner is rendered as a React component (ArchiveBanner) in mdx.tsx and injected in [id].tsx outside the next-mdx-remote eval context to avoid the _jsx runtime error.

Generated with [Devin](https://cli.devin.ai/docs)

### Page Header After

<img width="744" height="605" alt="image" src="https://github.com/user-attachments/assets/200152fe-a25e-455b-ae66-7fe8caaf7169" />
